### PR TITLE
Fix: Use robust relative paths for data output

### DIFF
--- a/src/data/data_fetch_all_timeframes_binance.py
+++ b/src/data/data_fetch_all_timeframes_binance.py
@@ -2,6 +2,24 @@ from binance.client import Client
 import pandas as pd
 import os
 
+# --- START: Robust Path Generation ---
+# This block ensures that file paths are generated relative to the script's location,
+# making the script work correctly no matter where it's run from.
+
+# 1. Get the absolute path of the current script file
+# e.g., /Users/jopanda/bootcamp-aipm/cryptopulse-AI/src/data/data_fetch_all_timeframes_binance.py
+script_path = os.path.abspath(__file__)
+
+# 2. Get the project root directory by going up the directory tree
+# From /.../src/data/ -> /.../src/ -> /.../ (the project root)
+project_root = os.path.dirname(os.path.dirname(os.path.dirname(script_path)))
+
+# 3. Construct the full, robust path to the target 'data/raw' directory
+output_dir = os.path.join(project_root, 'data', 'raw')
+
+# --- END: Robust Path Generation ---
+
+
 client = Client()
 timeframes = ['3m', '5m', '15m', '1h', '4h', '1d', '1w'] 
 
@@ -16,8 +34,12 @@ for tf in timeframes:
     df = df[['open_time', 'open', 'high', 'low', 'close', 'volume']].astype(float)
     df['open_time'] = pd.to_datetime(df['open_time'], unit='ms')
     
-    os.makedirs('../../data/raw', exist_ok=True)
-    csv_path = f'../../data/raw/btc_{tf}_raw.csv'
+    # Use the robust path to create the directory
+    os.makedirs(output_dir, exist_ok=True)
+    
+    # Use the robust path to create the full CSV file path
+    csv_path = os.path.join(output_dir, f'btc_{tf}_raw.csv')
+    
     df.to_csv(csv_path, index=False)
     print(f"✅ {len(df):,} rows → {csv_path}")
 


### PR DESCRIPTION
This PR fixes the data path generation in the data_fetch_all_timeframes_binance.py script.

It replaces the fragile ../../ path with a robust path generated relative to the script's own file location. This ensures data is always saved correctly inside the project's data/raw directory, regardless of where the script is run from.